### PR TITLE
fix: prevent inconsistent values error for sensitive attribute on indexer update

### DIFF
--- a/internal/provider/indexer_resource.go
+++ b/internal/provider/indexer_resource.go
@@ -209,8 +209,12 @@ func (r *IndexerResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	tflog.Trace(ctx, "created "+indexerResourceName+": "+strconv.Itoa(int(response.GetId())))
+	// Save fields from plan to avoid inconsistent result error if API added/changed fields
+	planFields := indexer.Fields
 	// Generate resource state struct.
 	indexer.write(ctx, response, &resp.Diagnostics)
+	// Restore fields to match plan
+	indexer.Fields = planFields
 	resp.Diagnostics.Append(resp.State.Set(ctx, indexer)...)
 }
 
@@ -259,8 +263,12 @@ func (r *IndexerResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	tflog.Trace(ctx, "updated "+indexerResourceName+": "+strconv.Itoa(int(response.GetId())))
+	// Save fields from plan to avoid inconsistent result error if API added/changed fields
+	planFields := indexer.Fields
 	// Generate resource state struct.
 	indexer.write(ctx, response, &resp.Diagnostics)
+	// Restore fields to match plan
+	indexer.Fields = planFields
 	resp.Diagnostics.Append(resp.State.Set(ctx, indexer)...)
 }
 


### PR DESCRIPTION
Fixes #285

When updating or creating an indexer, the API response fields are used to overwrite the state. Because \ields\ is a \Required\ attribute and not \Computed\, Terraform strictly forbids modifying it from the planned state. When the fields set changes due to Prowlarr defaults being returned or due to sensitive value masking, it triggers an \inconsistent values for sensitive attribute\ state drift error. This fix restores the plan's exact fields just before updating the state.